### PR TITLE
Add support for training models where some layers are frozen

### DIFF
--- a/dfw/dfw.py
+++ b/dfw/dfw.py
@@ -62,6 +62,8 @@ class DFW(optim.Optimizer):
         for group in self.param_groups:
             wd = group['weight_decay']
             for param in group['params']:
+                if param.grad is None:
+                    continue
                 w_dict[param]['delta_t'] = param.grad.data
                 w_dict[param]['r_t'] = wd * param.data
 
@@ -71,6 +73,8 @@ class DFW(optim.Optimizer):
             eta = group['eta']
             mu = group['momentum']
             for param in group['params']:
+                if param.grad is None:
+                    continue
                 state = self.state[param]
                 delta_t, r_t = w_dict[param]['delta_t'], w_dict[param]['r_t']
 
@@ -94,6 +98,8 @@ class DFW(optim.Optimizer):
         for group in self.param_groups:
             eta = group['eta']
             for param in group['params']:
+                if param.grad is None:
+                    continue
                 delta_t, r_t = w_dict[param]['delta_t'], w_dict[param]['r_t']
                 num -= eta * torch.sum(delta_t * r_t)
                 denom += eta * delta_t.norm() ** 2


### PR DESCRIPTION
I tried to use the DFW optimizer to train a model where the embedding layer was frozen (i.e. did not require gradients), but this caused the following error:

```
Traceback (most recent call last):
...
    self.optimizer.step(lambda: float(loss))
  File "/usr/local/lib/python3.7/site-packages/torch/autograd/grad_mode.py", line 43, in decorate_no_grad
    return func(*args, **kwargs)
  File "/neural_worker/model/optimizer/dfw.py", line 59, in step
    w_dict[param]['delta_t'] = param.grad.data
AttributeError: 'NoneType' object has no attribute 'data'

```
The changes in this pull request fixes the issue by skipping the parameters that do not require gradients (compare with the PyTorch Adam implementation: https://github.com/pytorch/pytorch/blob/master/torch/optim/adam.py#L62-L63). 